### PR TITLE
[Bugfix] 배포후 새로고침시 404페이지 노출 수정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## 문제상황
배포 후에만 특정페이지에  (URL통해서) 직접 접근 or 특정페이지를 새로고침 시 404 페이지가 노출된다.

## 원인
- 개발환경 (여기서는 Vite) : 내장된 개발서버는 SPA에서 요청된 경로에 맞춰서 새로고침시에도 리다이렉트가 되도록 설정되어있기때문에 문제가 발생하지 않는다.
- 배포환경 : 배포된 서버에서는 오직 루트경로(` / `, `index.html`)만을 알고 있다. 그 경로에 맞는 요청에 대한 응답만을 할 수 있다. 그렇기 때문에 새로운 경로( ex. `/todos`)로 서버에 요청을 보내면 해당 경로에 대한 응답은 없기 때문에 404 페이지를 노출하게 된다. 즉 내가 만든 라우팅시스템은 클라이언트 시스템에서만 이해할 수 있는 시스템이기에 서버는 `/ 외의 경로`가 들어오면 ` / `로 리다이렉트를 하여 클라이언트의 라우팅 시스템에 의해서 요청된 페이지가 랜더링 될 수 있도록 만들어야 한다. 

## 해결
내가 배포한 서버(vercel 서버)에 설정을 해야한다. `vercel.json` 에 rewrite 옵션을 추가하는 파일을 만든다.
```json
{
  "rewrites": [
    { "source": "/(.*)", "destination": "/" }
  ]
}
```
→ 서버는 모든 요청을 `index.html`로 리다이렉트하여 클라이언트 측 라우터가 해당 경로를 처리할 수 있게 된다.
