### PR TITLE
[Fix] 라우트 데브툴 환경별 분리

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,3 +1,5 @@
-export default function Home() {
+const Home = () => {
   return <section>This is Home</section>
 }
+
+export default Home

--- a/src/pages/ShopMall.tsx
+++ b/src/pages/ShopMall.tsx
@@ -1,3 +1,5 @@
-export default function ShopMall() {
+const ShopMall = () => {
   return <section>This is ShopMall</section>
 }
+
+export default ShopMall

--- a/src/pages/Todos.tsx
+++ b/src/pages/Todos.tsx
@@ -1,9 +1,9 @@
+import { TodosProvider } from '@contexts/TodosContext'
 import Form from '@components/todos/Form'
 import Header from '@components/todos/Header'
 import Body from '@components/todos/Body'
-import { TodosProvider } from '@contexts/TodosContext'
 
-export default function Todos() {
+const Todos = () => {
   return (
     <TodosProvider>
       <section className="flex justify-center items-center w-full h-[calc(100vh-96px)]">
@@ -16,3 +16,5 @@ export default function Todos() {
     </TodosProvider>
   )
 }
+
+export default Todos

--- a/src/pages/Youtube.tsx
+++ b/src/pages/Youtube.tsx
@@ -1,3 +1,5 @@
-export default function Youtube() {
+const Youtube = () => {
   return <section>This is Youtube</section>
 }
+
+export default Youtube

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,10 +1,19 @@
 import { createRootRoute, Outlet } from '@tanstack/react-router'
-import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import Nav from '@components/common/Nav'
+import { lazy, Suspense } from 'react'
 
 export const Route = createRootRoute({
   component: () => <Root />,
 })
+
+const TanStackRouterDevtools =
+  process.env.NODE_ENV === 'production'
+    ? () => null
+    : lazy(() =>
+        import('@tanstack/router-devtools').then((res) => ({
+          default: res.TanStackRouterDevtools,
+        }))
+      )
 
 const Root = () => {
   return (
@@ -14,7 +23,10 @@ const Root = () => {
       <main>
         <Outlet />
       </main>
-      <TanStackRouterDevtools />
+
+      <Suspense>
+        <TanStackRouterDevtools />
+      </Suspense>
     </>
   )
 }


### PR DESCRIPTION
## 궁금한점
Q1. 왜 lazy + 동적 임포트를 통해서  `TanStackRouterDevtools` 을 import 할까?? 
     → 어떤 장점을 가질까??
A1. `TanStackRouterDevtools` 은 개발환경에만 필요하다. 그렇기 때문에 프로덕션 배포에는 해당 코드가 번들에 포함되지 않는 것이 좋다. 그래서 선언적 임포트가 아니라 동적 임포트를 통해서 필요한 곳에서만 이를 패키지를 임포트하여 사용할 수 있다.

Q2. 위 답변은 동적 임포트에 해당하는 답변인데... lazy와는 어떻게 연결되는가??
A2. lazy를 사용하면 Suspense와 결합하여 컴퍼넌트 **로딩에 대해 적은 코드로 직관적으로 표현 가능**하다. 또한 lazy를 사용하면 **코드스플릿을 자동**으로 해주기 때문에 편리하다. 